### PR TITLE
Adds ModMenu `library` badge.

### DIFF
--- a/resources/fabric.mod.json
+++ b/resources/fabric.mod.json
@@ -27,6 +27,8 @@
 		"config": "mixins.mm.json"
 	}],
 	"custom": {
-		"modmenu:api": true
+		"modmenu": {
+			"badges": [ "library" ]
+		}
 	}
 }

--- a/resources/fabric.mod.json
+++ b/resources/fabric.mod.json
@@ -27,6 +27,7 @@
 		"config": "mixins.mm.json"
 	}],
 	"custom": {
+		"modmenu:api": true,
 		"modmenu": {
 			"badges": [ "library" ]
 		}


### PR DESCRIPTION
This allows to filter library mods in [ModMenu](https://github.com/TerraformersMC/ModMenu/wiki/API#badges).
Fixes #12 and avoids confusion described in #13 and #14