### PR TITLE
Fix/avoid re-entrance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 		}
 	}
 	dependencies {
-        classpath 'com.github.Chocohead:fabric-loom:415c6b'
+        classpath 'com.github.Chocohead:fabric-loom:49aa217'
 	}
 }
 
@@ -34,9 +34,9 @@ minecraft {
 }
 
 dependencies {
-	minecraft "com.mojang:minecraft:1.14 Pre-Release 3"
-	mappings "net.fabricmc:yarn:1.14 Pre-Release 3+build.1:tiny@gz"
-	modCompile "net.fabricmc:fabric-loader:0.7.0+build.171"
+	minecraft "com.mojang:minecraft:1.14"
+	mappings "net.fabricmc:yarn:1.14+build.1:tiny@gz"
+	modCompile "net.fabricmc:fabric-loader:0.10.0+build.208"
 }
 
 sourceSets {

--- a/example/resources/fabric.mod.json
+++ b/example/resources/fabric.mod.json
@@ -22,7 +22,7 @@
 		]
 	},
 	"depends": {
-		"fabricloader": ">=0.7.0",
+		"fabricloader": ">=0.10.0",
 		"mm": ">=2.3"
 	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+networkTimeout=10000
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/resources/fabric.mod.json
+++ b/resources/fabric.mod.json
@@ -21,7 +21,7 @@
 		]
 	},
 	"depends": {
-		"fabricloader": ">=0.7.0"
+		"fabricloader": ">=0.10.0"
 	},
 	"mixins": [{
 		"config": "mixins.mm.json"

--- a/src/com/chocohead/mm/EnumExtender.java
+++ b/src/com/chocohead/mm/EnumExtender.java
@@ -38,7 +38,7 @@ import com.chocohead.mm.api.EnumAdder;
 import com.chocohead.mm.api.EnumAdder.EnumAddition;
 
 public final class EnumExtender {
-	public static final Map<String, Object[]> POOL = new HashMap<>();
+	public static final Map<String, Supplier<Object[]>> POOL = new HashMap<>();
 
 
 	static Consumer<ClassNode> makeEnumExtender(EnumAdder builder) {
@@ -190,6 +190,8 @@ public final class EnumExtender {
 					POOL.put(poolKey, addition.getParameters());
 					fieldSetting.add(new LdcInsnNode(poolKey));
 					fieldSetting.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, "java/util/Map", "get", "(Ljava/lang/Object;)Ljava/lang/Object;", true));
+					fieldSetting.add(new TypeInsnNode(Opcodes.CHECKCAST, "java/util/function/Supplier"));
+					fieldSetting.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, "java/util/function/Supplier", "get", "()Ljava/lang/Object;", true));
 					fieldSetting.add(new TypeInsnNode(Opcodes.CHECKCAST, "[Ljava/lang/Object;"));
 					fieldSetting.add(new VarInsnNode(Opcodes.ASTORE, 0));
 

--- a/src/com/chocohead/mm/EnumExtender.java
+++ b/src/com/chocohead/mm/EnumExtender.java
@@ -176,6 +176,10 @@ public final class EnumExtender {
 			InsnList arrayFilling = new InsnList();
 
 			for (EnumAddition addition : builder.getAdditions()) {
+				String additionType = addition.isEnumSubclass() ? anonymousClassFactory.get() : node.name;
+				if (addition.isEnumSubclass() && node.permittedSubclasses != null) {
+					node.permittedSubclasses.add(additionType);
+				}
 				node.visitField(Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL + Opcodes.ACC_STATIC + Opcodes.ACC_ENUM, addition.name, 'L' + node.name + ';', null, null);
 
 				LabelNode stuffStart;
@@ -193,7 +197,6 @@ public final class EnumExtender {
 					fieldSetting.add(stuffStart);
 				} else stuffStart = null;
 
-				String additionType = addition.isEnumSubclass() ? anonymousClassFactory.get() : node.name;
 				fieldSetting.add(new TypeInsnNode(Opcodes.NEW, additionType));
 				fieldSetting.add(new InsnNode(Opcodes.DUP));
 

--- a/src/com/chocohead/mm/api/EnumAdder.java
+++ b/src/com/chocohead/mm/api/EnumAdder.java
@@ -67,8 +67,8 @@ public final class EnumAdder {
 		 *
 		 * @throws IllegalArgumentException If the factory produces an invalid parameter array
 		 */
-		public Object[] getParameters() {
-			return checkParameters(parameterFactory.get());
+		public Supplier<Object[]> getParameters() {
+			return () -> checkParameters(parameterFactory.get());
 		}
 
 		/**


### PR DESCRIPTION
Based on my other PR since I can't build otherwise.
Mixin strictly disallows re-entrance during transformation so we should avoid evaluating args suppliers at transformation-time, instead storing the supplier and evaluating it at runtime.
Currently if an arg supplier causes a classload for a class that has a mixin it will crash.